### PR TITLE
Add Babel Jest setup

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react']
+};

--- a/package.json
+++ b/package.json
@@ -2,5 +2,20 @@
   "dependencies": {
     "simple-peer": "^9.11.1",
     "socket.io-client": "^4.8.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/preset-env": "^7.28.0",
+    "@babel/preset-react": "^7.27.1",
+    "babel-jest": "^30.0.4",
+    "jest": "^30.0.4"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "transform": {
+      "^.+.[tj]sx?$": "babel-jest"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add Babel Jest configuration so Jest can handle ES modules
- update package.json to use `babel-jest`

## Testing
- `npm install`
- `npm test -- -w=0` *(fails: Cannot find module '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_687256700fd4832c899f677375db56ed